### PR TITLE
jdt.core.binaries is not a test plugin

### DIFF
--- a/org.eclipse.jdt.core.tests.binaries/pom.xml
+++ b/org.eclipse.jdt.core.tests.binaries/pom.xml
@@ -19,5 +19,5 @@
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.tests.binaries</artifactId>
   <version>1.0.250-SNAPSHOT</version>
-  <packaging>eclipse-test-plugin</packaging>
+  <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Currently jdt.core.binaries is packed as a "eclipse-test-plugin" but actually do not contain any tests nor code.

"eclipse-plugin" is much more suitable here, due to how "eclipse-test-plugin" works it pulls in a lot of additional (test) dependencies otherwhise.

@akurtakov or is there anything magically requiring this? I just noticed this while debugging the new Tycho 4 resolver and wondered why a plugin with no dependencies is pulling in a whole lot of stuff...