### PR TITLE
POM and product version changes for 4.29 release

### DIFF
--- a/org.eclipse.jdt.core.tests.binaries/pom.xml
+++ b/org.eclipse.jdt.core.tests.binaries/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.jdt.core.binaries</artifactId>
     <groupId>eclipse.jdt.core</groupId>
-    <version>4.28.0-SNAPSHOT</version>
+    <version>4.29.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.tests.binaries</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.28.0-SNAPSHOT</version>
+    <version>4.29.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in
https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1100


