### PR TITLE
Version bump

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,33 @@
+pipeline {
+	options {
+		timeout(time: 40, unit: 'MINUTES')
+		buildDiscarder(logRotator(numToKeepStr:'5'))
+	}
+	agent {
+		label "centos-latest"
+	}
+	tools {
+		maven 'apache-maven-latest'
+		jdk 'temurin-jdk17-latest'
+	}
+	stages {
+		stage('Build') {
+			steps {
+				wrap([$class: 'Xvnc', useXauthority: true]) {
+					sh """
+					mvn clean verify --batch-mode --fail-at-end -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+						-Pbuild-individual-bundles -Pbree-libs -Papi-check \
+						-Dcompare-version-with-baselines.skip=false \
+						-Dproject.build.sourceEncoding=UTF-8 
+					"""
+				}
+			}
+			post {
+				always {
+					archiveArtifacts artifacts: '*.log,*/target/work/data/.metadata/*.log,*/tests/target/work/data/.metadata/*.log,apiAnalyzer-workspace/.metadata/*.log', allowEmptyArchive: true
+					publishIssues issues:[scanForIssues(tool: java()), scanForIssues(tool: mavenConsole())]
+				}
+			}
+		}
+	}
+}

--- a/org.eclipse.jdt.core.tests.binaries/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.binaries/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.binaries
-Bundle-Version: 1.0.250.qualifier
+Bundle-Version: 1.0.300.qualifier
 Bundle-Vendor: %providerName
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Eclipse-BundleShape: dir

--- a/org.eclipse.jdt.core.tests.binaries/pom.xml
+++ b/org.eclipse.jdt.core.tests.binaries/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.tests.binaries</artifactId>
-  <version>1.0.250-SNAPSHOT</version>
+  <version>1.0.300-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Supposed to fix failing master build
(https://ci.eclipse.org/platform/job/eclipse.platform.releng.aggregator/job/master/) :
[ERROR] Failed to execute goal
org.eclipse.tycho.extras:tycho-p2-extras-plugin:4.0.5-SNAPSHOT:compare-version-with-baselines (compare-attached-artifacts-with-release) on project org.eclipse.jdt.core.tests.binaries: Version has moved backwards for (org.eclipse.jdt.core.tests.binaries/1.0.250.qualifier). Baseline has 1.0.250.v20210713-1056) with delta: 0.0.0 -> [Help 1] 14:19:05  org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal
org.eclipse.tycho.extras:tycho-p2-extras-plugin:4.0.5-SNAPSHOT:compare-version-with-baselines (compare-attached-artifacts-with-release) on project org.eclipse.jdt.core.tests.binaries: Version has moved backwards for (org.eclipse.jdt.core.tests.binaries/1.0.250.qualifier). Baseline has 1.0.250.v20210713-1056) with delta: 0.0.0

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/eclipse-jdt/.github/blob/main/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See https://github.com/eclipse-jdt/.github/security/policy
-->

## What it does
<!-- Include relevant issues and describe how they are addressed. -->

## How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

## Author checklist

- [ ] I have thoroughly tested my changes
- [ ] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [ ] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
