### PR TITLE
Bump EE to 1.8

### DIFF
--- a/org.eclipse.jdt.core.tests.binaries/.classpath
+++ b/org.eclipse.jdt.core.tests.binaries/.classpath
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/org.eclipse.jdt.core.tests.binaries/.settings/org.eclipse.jdt.core.prefs
+++ b/org.eclipse.jdt.core.tests.binaries/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,6 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=warning
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=warning
-org.eclipse.jdt.core.compiler.source=1.7
+org.eclipse.jdt.core.compiler.source=1.8

--- a/org.eclipse.jdt.core.tests.binaries/META-INF/MANIFEST.MF
+++ b/org.eclipse.jdt.core.tests.binaries/META-INF/MANIFEST.MF
@@ -2,8 +2,8 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.jdt.core.tests.binaries
-Bundle-Version: 1.0.300.qualifier
+Bundle-Version: 1.1.0.qualifier
 Bundle-Vendor: %providerName
-Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Eclipse-BundleShape: dir
 Automatic-Module-Name: org.eclipse.jdt.core.tests.binaries

--- a/org.eclipse.jdt.core.tests.binaries/pom.xml
+++ b/org.eclipse.jdt.core.tests.binaries/pom.xml
@@ -18,6 +18,6 @@
   </parent>
   <groupId>org.eclipse.jdt</groupId>
   <artifactId>org.eclipse.jdt.core.tests.binaries</artifactId>
-  <version>1.0.300-SNAPSHOT</version>
+  <version>1.1.0-SNAPSHOT</version>
   <packaging>eclipse-plugin</packaging>
 </project>


### PR DESCRIPTION
Not sure it is needed during build as I don't see anything that is compiled here, but better to be safe.

See https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/2197
