### PR TITLE
Build on ubuntu-latest

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
 		buildDiscarder(logRotator(numToKeepStr:'5'))
 	}
 	agent {
-		label "centos-latest"
+		label "ubuntu-latest"
 	}
 	tools {
 		maven 'apache-maven-latest'


### PR DESCRIPTION
## What it does
centos-latest is deprecated as per:
https://github.com/eclipse-cbi/jiro-agents/blob/master/README.md

## Author checklist

- [x] I have thoroughly tested my changes
- [x] The change is following the [coding conventions](https://wiki.eclipse.org/Platform/How_to_Contribute#Coding_Conventions)
- [x] I have signed the [Eclipse Contributor Agreement (ECA)](https://www.eclipse.org/legal/ECA.php)
